### PR TITLE
refact: HashTagInputGroup 패딩, 그림자 figma에 맞게 수정

### DIFF
--- a/Tlog/app/src/main/java/com/tlog/ui/component/share/HashtagInputGroup.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/component/share/HashtagInputGroup.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -63,21 +64,22 @@ fun HashtagInputGroup(
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         items(hashTags) { tag ->
-            val textWidth = 4 * tag.length + 25 // 박스 크기
 
             Surface(
                 shape = RoundedCornerShape(50),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .shadow(3.dp, RoundedCornerShape(50))
+                    .padding(1.dp) // 상하좌우 그림자 짤리기 방지
+                    .shadow(2.dp, RoundedCornerShape(50))
                     .background(Color.White)
             ) {
 
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
+                        .background(Color.White)
                         .height(22.dp)
-                        .width(textWidth.dp),
+                        .padding(horizontal = 10.dp, vertical = 5.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(


### PR DESCRIPTION
## 작업 동기 및 이슈
- #133 

## 추가 및 변경사항
- 피그마와 살짝 다른 부분 체크하고 변경
 
## 기타

## 실행 화면
(변경 후)
<img width="212" alt="스크린샷 2025-05-30 오후 7 48 33" src="https://github.com/user-attachments/assets/46c07b3d-7852-4600-bb75-8ed407181cd1" />
