### PR TITLE
feat: 사용자 회원가입 로직 구현

### DIFF
--- a/Tlog/app/src/main/java/com/tlog/api/LoginApi.kt
+++ b/Tlog/app/src/main/java/com/tlog/api/LoginApi.kt
@@ -2,6 +2,7 @@ package com.tlog.api
 
 import com.tlog.data.api.BaseResponse
 import com.tlog.data.api.LoginRequest
+import com.tlog.data.api.RegisterRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Header
@@ -21,6 +22,11 @@ interface LoginApi {
     @POST("/api/notify")
     suspend fun setFcmToken(
         @Body fcmTokenBody: FcmTokenBody
+    ): BaseResponse<Unit>
+
+    @POST("/api/auth/register/user")
+    suspend fun ssoRegister(
+        @Body request: RegisterRequest
     ): BaseResponse<Unit>
 }
 

--- a/Tlog/app/src/main/java/com/tlog/data/api/RegisterRequest.kt
+++ b/Tlog/app/src/main/java/com/tlog/data/api/RegisterRequest.kt
@@ -1,0 +1,11 @@
+package com.tlog.data.api
+
+data class RegisterRequest(
+    val type: String,
+    val accessToken: String,
+    val userProfile: UserProfileDto
+)
+
+data class UserProfileDto(
+    val tbtiValue: String
+)

--- a/Tlog/app/src/main/java/com/tlog/data/local/UserPreferences.kt
+++ b/Tlog/app/src/main/java/com/tlog/data/local/UserPreferences.kt
@@ -30,6 +30,9 @@ class UserPreferences @Inject constructor(
     private val FCM_TOKEN = stringPreferencesKey("fcmToken")
     private val SNS_ID = stringPreferencesKey("snsId")
 
+    private val TMP_SOCIAL_ACCESS_TOKEN = stringPreferencesKey("tmpSocialAccessToken")
+    private val TMP_SOCIAL_TYPE = stringPreferencesKey("tmpSocialType")
+
     suspend fun saveTokensAndUserId(accessToken: String, refreshToken: String, firebaseCustomToken: String? = null) {
         val (userId, snsId) = userIdFromJwt(accessToken)
 
@@ -90,6 +93,28 @@ class UserPreferences @Inject constructor(
     suspend fun getFcmToken(): String? {
         val prefs = context.dataStore.data.first()
         return prefs[FCM_TOKEN]
+    }
+
+    suspend fun saveTmpSocialAccessToken(token: String) {
+        context.dataStore.edit { preferences ->
+            preferences[TMP_SOCIAL_ACCESS_TOKEN] = token
+        }
+    }
+
+    suspend fun getTmpSocialAccessToken(): String? {
+        val prefs = context.dataStore.data.first()
+        return prefs[TMP_SOCIAL_ACCESS_TOKEN]
+    }
+
+    suspend fun saveTmpSocialType(type: String) {
+        context.dataStore.edit { preferences ->
+            preferences[TMP_SOCIAL_TYPE] = type
+        }
+    }
+
+    suspend fun getTmpSocialType(): String? {
+        val prefs = context.dataStore.data.first()
+        return prefs[TMP_SOCIAL_TYPE]
     }
 
 

--- a/Tlog/app/src/main/java/com/tlog/ui/navigation/NavHost.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/navigation/NavHost.kt
@@ -57,7 +57,7 @@ fun NavHost(
     val viewModel: MyNavViewModel = hiltViewModel() // 고민 좀 해볼건데 일단 이렇게
 
 
-    NavHost(navController = navController, startDestination = "myPage") {
+    NavHost(navController = navController, startDestination = "login") {
         // Main
         composable("main") {
             MainScreen(navController = navController)

--- a/Tlog/app/src/main/java/com/tlog/ui/screen/beginning/TbtiResultScreen.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/screen/beginning/TbtiResultScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,14 +30,20 @@ import com.tlog.ui.style.Body1Regular
 import com.tlog.ui.theme.MainFont
 import com.tlog.viewmodel.beginning.TbtiResultViewModel
 import androidx.navigation.NavController
+import com.tlog.viewmodel.beginning.TbtiTestViewModel
+import com.tlog.viewmodel.beginning.login.LoginViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 fun TbtiResultScreen(
     tbtiResultCode: String,
     viewModel: TbtiResultViewModel = hiltViewModel(),
+    tbtiTestViewModel: TbtiTestViewModel = hiltViewModel(),
+    loginViewModel: LoginViewModel = hiltViewModel(),
     traitScores: Map<String, Int>, // ViewModel에서 전달받는 점수 맵
     navController: NavController
 ) {
+
     val scrollState = rememberScrollState()
     val leftLabels = listOf("S", "E", "L", "A")
     val rightLabels = listOf("R", "O", "N", "I")
@@ -234,13 +241,15 @@ fun TbtiResultScreen(
 
             Spacer(modifier = Modifier.height(30.dp))
 
+            val tbtiValue = "${traitScores["S"] ?: 0}" +
+                    "${traitScores["E"] ?: 0}" +
+                    "${traitScores["L"] ?: 0}" +
+                    "${traitScores["A"] ?: 0}"
+
             MainButton(
                 text = "시작하기",
                 onClick = {
-                    navController.navigate("main") {
-                        //쌓여있는 이전화면 스택에서 없애기
-                        popUpTo("tbtiResult") { inclusive = true }
-                    }
+                    viewModel.registerUser(navController, tbtiValue)
                 },
                 modifier = Modifier
                     .padding(horizontal = 24.dp)

--- a/Tlog/app/src/main/java/com/tlog/viewmodel/beginning/TbtiResultViewModel.kt
+++ b/Tlog/app/src/main/java/com/tlog/viewmodel/beginning/TbtiResultViewModel.kt
@@ -3,10 +3,19 @@ package com.tlog.viewmodel.beginning
 import android.util.Log
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.NavController
+import com.google.android.gms.common.api.Response
+import com.tlog.api.LoginApi
+import com.tlog.data.api.BaseResponse
+import com.tlog.data.api.RegisterRequest
 import com.tlog.data.api.TbtiDescriptionResponse
+import com.tlog.data.api.UserProfileDto
+import com.tlog.data.local.UserPreferences
 import com.tlog.data.repository.TbtiRepository
+import com.tlog.viewmodel.beginning.login.LoginViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
 import kotlinx.coroutines.launch
@@ -14,8 +23,11 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class TbtiResultViewModel @Inject constructor(
-    private val tbtiRepository: TbtiRepository
+    private val tbtiRepository: TbtiRepository,
+    private val loginApi: LoginApi,
+    private val userPreferences: UserPreferences
 ): ViewModel() {
+
     private val _tbtiDescription = mutableStateOf<TbtiDescriptionResponse?>(null)
     val tbtiDescription: State<TbtiDescriptionResponse?> = _tbtiDescription
 
@@ -27,6 +39,40 @@ class TbtiResultViewModel @Inject constructor(
                 Log.d("TBTI", "tbtiDescription !!!! : ${_tbtiDescription.value}")
             } catch (e: Exception) {
                 Log.e("TbtiTestViewModel", "설명 데이터 요청 실패", e)
+            }
+        }
+    }
+
+    fun registerUser(
+        navController: NavController,
+        tbtiValue: String) {
+        viewModelScope.launch {
+            val socialAccessToken = userPreferences.getTmpSocialAccessToken()
+            val socialType = userPreferences.getTmpSocialType()
+
+            if (socialAccessToken.isNullOrEmpty()) {
+                Log.e("TbtiResultViewModel", "AccessToken이 없습니다!")
+                return@launch
+            }
+
+            val request = RegisterRequest(
+                type = socialType.toString(),
+                accessToken = socialAccessToken,
+                userProfile = UserProfileDto(tbtiValue = tbtiValue)
+            )
+
+            try {
+                val response = loginApi.ssoRegister(request)
+                if (response.status == 200) {
+                    navController.navigate("main") {
+                        popUpTo("tbtiResult") { inclusive = true }
+                    }
+                    Log.d("TbtiResultViewModel", "회원가입 성공 후 메인으로 이동")
+                } else {
+                    Log.e("TbtiResultViewModel", "회원가입 실패: ${response.status}")
+                }
+            } catch (e: Exception) {
+                Log.e("TbtiResultViewModel", "회원가입 실패", e)
             }
         }
     }


### PR DESCRIPTION
## 작업 동기 및 이슈

- #168  

## 추가 및 변경사항

-  사용자가 로그인했을때 토큰은 있는데 tbti가 없을경우 tbti test화면으로 넘기고 결과 페이지 보여주고 메인페이지로 넘어가도록 수정

## 기타

- 실행화면은 따로 없습니다 직접 보는게 좋을듯
- 회원가입하고 바로 마이페이지 들어가서 tbtiString 요청할때 뭔가 문제가 있는걸로 판단됨 마지막 테스트때는 성공했지만 추후 다시 테스트 필요
- 진행을 위해 userpreferences로 datastore에 저장한 엑세스토큰, 소셜로그인 타입 추후 삭제 함수 구현 필요

## 실행 화면
