### PR TITLE
feat: 팀 생성 스크린 UI 수정

### DIFF
--- a/Tlog/app/src/main/java/com/tlog/ui/component/share/TitleInputField.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/component/share/TitleInputField.kt
@@ -26,16 +26,17 @@ import com.tlog.ui.theme.MainFont
 
 @Composable
 fun TitleInputField (
+    modifier: Modifier = Modifier,
     text: String,
     value: String,
     onValueChange: (String) -> Unit,
     placeholderText: String,
     singleLine: Boolean = true,
-    trailingIcon: @Composable (() -> Unit)? = null,
-    modifier: Modifier = Modifier
+    trailingIcon: @Composable (() -> Unit)? = null
 ) {
     Text(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth(),
         text = text,
         style = BodyTitle,
         textAlign = TextAlign.Center
@@ -43,32 +44,11 @@ fun TitleInputField (
 
     Spacer(modifier = Modifier.height(25.dp))
 
-    TextField(
+
+    BottomLineInputField(
         value = value,
         onValueChange = onValueChange,
-        placeholder = { Text(
-            text = placeholderText,
-            fontSize = 13.sp,
-            fontFamily = MainFont,
-            fontWeight = FontWeight.Thin
-        ) },
+        placeholder = placeholderText,
         singleLine = singleLine,
-        shape = RoundedCornerShape(20),
-        colors = OutlinedTextFieldDefaults.colors(
-            focusedBorderColor = Color.Transparent,     // 포커스됐을 때 아웃라인 색
-            unfocusedBorderColor = Color.Transparent,  // 포커스 없을 때 아웃라인 색
-            cursorColor = MainColor
-        ),
-        textStyle = TextStyle(
-            fontFamily = MainFont,
-            fontWeight = FontWeight.Thin
-        ),
-        trailingIcon = trailingIcon,
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 24.dp)
-            .shadow(4.dp, shape = RoundedCornerShape(24.dp)) // 그림자 만들고
-            .clip(RoundedCornerShape(24.dp)) // 크기에 맞게 짜름
-            .background(Color.White) // 백그라운드가 있어야 그림자가 알맞은 위치에 보임
     )
 }

--- a/Tlog/app/src/main/java/com/tlog/ui/screen/team/TeamCreateScreen.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/screen/team/TeamCreateScreen.kt
@@ -2,10 +2,12 @@ package com.tlog.ui.screen.team
 
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -53,6 +55,7 @@ fun TeamCreateScreen(
             .background(Color.White)
             .imePadding()           // 키보드가 딸려 올라오도록
             .windowInsetsPadding(WindowInsets.systemBars)
+            .padding(horizontal = 24.dp)
 
     ) {
         TopBar(
@@ -61,7 +64,10 @@ fun TeamCreateScreen(
 
         Spacer(modifier = Modifier.height(35.dp))
 
+
         TitleInputField(
+            modifier = Modifier
+                .padding(horizontal = 24.dp),
             text = "팀 이름을 정해주세요!",
             value = viewModel.teamName.value,
             onValueChange = {
@@ -69,6 +75,7 @@ fun TeamCreateScreen(
             },
             placeholderText = "입력해주세요",
         )
+
 
         Spacer(modifier = Modifier.weight(1f))
 
@@ -80,7 +87,7 @@ fun TeamCreateScreen(
                 },
                 modifier = Modifier
                     .height(70.dp)
-                    .padding(start = 24.dp, end = 24.dp, bottom = 15.dp)
+                    .padding(bottom = 15.dp)
             )
         }
     }


### PR DESCRIPTION
## 작업 동기 및 이슈
- #188 

## 추가 및 변경사항
- 팀 이름 생성하는 스크린 UI 수정
 
## 기타

## 실행 화면
<img width="417" alt="스크린샷 2025-06-23 오후 9 22 20" src="https://github.com/user-attachments/assets/8c21e36b-693e-46e6-8113-585e307d4517" />
<img width="421" alt="스크린샷 2025-06-23 오후 9 22 13" src="https://github.com/user-attachments/assets/ede63c95-966b-49c4-9b91-e01c27585c9f" />
