### PR TITLE
refact: 민감한 키값 로컬로 이동

### DIFF
--- a/Tlog/app/build.gradle.kts
+++ b/Tlog/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -9,9 +12,16 @@ plugins {
     id("com.google.gms.google-services")
 }
 
+
+
+
 android {
     namespace = "com.tlog"
     compileSdk = 35
+
+    val localProperties = Properties()
+    localProperties.load(FileInputStream(rootProject.file("local.properties")))
+
 
     defaultConfig {
         applicationId = "com.tlog"
@@ -19,21 +29,29 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+
         //Manifest에서 사용하는 용도
         //카카오 네이티브 앱키
-        manifestPlaceholders["KakaoScheme"] = "kakao${project.findProperty("KAKAO_NATIVE_APP_KEY")}"
-        manifestPlaceholders["KakaoNativeAppKey"] = "${project.findProperty("KAKAO_NATIVE_APP_KEY")}"
+
+        val kakaoNativeAppKey = localProperties.getProperty("KAKAO_NATIVE_APP_KEY")
+        manifestPlaceholders["KakaoScheme"] = "kakao${kakaoNativeAppKey}"
+        manifestPlaceholders["KakaoNativeAppKey"] = kakaoNativeAppKey
 
         //실제 코드에서 사용하는 용도
         //구글 클라이언트 ID
-        buildConfigField("String","GOOGLE_CLIENT_ID", "\"${property("GOOGLE_CLIENT_ID")}\"")
+        val googleClientId =  localProperties.getProperty("GOOGLE_CLIENT_ID")
+        buildConfigField("String", "GOOGLE_CLIENT_ID", "\"$googleClientId\"")
+
         //카카오 네이티브 앱키
-        buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"${project.findProperty("KAKAO_NATIVE_APP_KEY")}\"")
+        buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"${kakaoNativeAppKey}\"")
+
         //네이버 클라이언트 ID, 클라이언트 시크릿
-        buildConfigField("String", "NAVER_CLIENT_ID", "\"${project.findProperty("NAVER_CLIENT_ID")}\"")
-        buildConfigField("String", "NAVER_CLIENT_SECRET", "\"${project.findProperty("NAVER_CLIENT_SECRET")}\"")
+        val naverClientId = localProperties.getProperty("NAVER_CLIENT_ID")
+        val naverClientSecret = localProperties.getProperty("NAVER_CLIENT_SECRET")
+        buildConfigField("String", "NAVER_CLIENT_ID", "\"$naverClientId\"")
+        buildConfigField("String", "NAVER_CLIENT_SECRET", "\"$naverClientSecret\"")
     }
 
     buildTypes {

--- a/Tlog/gradle.properties
+++ b/Tlog/gradle.properties
@@ -21,7 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-KAKAO_NATIVE_APP_KEY=1672339d7fda09e058a54ca329612700
-GOOGLE_CLIENT_ID=248288207145-5okvu79rs2mnr9963juvpagf8l4p57t8.apps.googleusercontent.com
-NAVER_CLIENT_ID=B1TWiZjz425aIf9yeepw
-NAVER_CLIENT_SECRET=t6lGxiGIC_


### PR DESCRIPTION
## 작업 동기 및 이슈
- #190 

## 추가 및 변경사항
- 민감한 키들 gradle.properties -> local로 옮김
 
## 기타
- 키 재발급 후 카톡으로 안내 드릴게요 기존 키는 깃헙에 있어서 날립시닷

## 실행 화면
