### PR TITLE
feat: SNS 게시물 작성 스크린 수정

### DIFF
--- a/Tlog/app/src/main/java/com/tlog/ui/screen/sns/SnsPostWriteDetailScreen.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/screen/sns/SnsPostWriteDetailScreen.kt
@@ -32,15 +32,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.tlog.data.model.sns.TravelCourse
 import com.tlog.ui.component.share.TextButtonTopBar
 import com.tlog.ui.style.Body1Regular
 import com.tlog.ui.theme.MainColor
+import com.tlog.ui.theme.MainFont
 import com.tlog.viewmodel.sns.SnsPostViewModel
 
-
+@Preview(showBackground = true)
 @Composable
 fun SnsPostWriteDetailScreen(
     viewModel: SnsPostViewModel = viewModel()
@@ -52,6 +57,7 @@ fun SnsPostWriteDetailScreen(
         modifier = Modifier
             .fillMaxSize()
             .windowInsetsPadding(WindowInsets.systemBars)
+            .background(Color.White)
             .verticalScroll(rememberScrollState())
     ) {
         TextButtonTopBar(
@@ -84,11 +90,21 @@ fun SnsPostWriteDetailScreen(
             },
             placeholder = {
                 Text(
-                    text = "게시물 내용을 입력해 주세요.",
-                    style = Body1Regular
+                    text = "게시물 내용 쓰기",
+                    style = TextStyle(
+                        fontFamily = MainFont,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 15.sp,
+                        color = Color.Black
+                    ),
                 )
             },
-            textStyle = Body1Regular,
+            textStyle = TextStyle(
+                fontFamily = MainFont,
+                fontWeight = FontWeight.Normal,
+                fontSize = 15.sp,
+                color = Color.Black
+            ),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = Color.Transparent,
                 unfocusedBorderColor = Color.Transparent,


### PR DESCRIPTION
## 작업 동기 및 이슈
- #210 

## 추가 및 변경사항
- SNS 게시물 작성 스크린 수정
 
## 기타
- 수정사항이 거의 없어서 SNS 게시글 내용 작성하는 부분 백그라운드 컬러랑 텍스트 스타일 정도 수정했습니다.

## 실행 화면
<img width="387" height="837" alt="스크린샷 2025-07-13 오후 3 27 23" src="https://github.com/user-attachments/assets/5119a716-9614-496b-b028-3b1d76cfb0d2" />
<img width="387" height="836" alt="스크린샷 2025-07-13 오후 3 27 45" src="https://github.com/user-attachments/assets/10ec6832-d691-4327-9dcf-889e8fc7936c" />