### PR TITLE
Feat: 리뷰에서 유저 터치 시 SNS로 이동하지 않도록 수정

### DIFF
--- a/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewItem.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewItem.kt
@@ -40,8 +40,7 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun ReviewItem(
-    review: Review,
-    onClick: (String) -> Unit
+    review: Review
 ) {
     val instant = Instant.parse(review.createdAt)
 
@@ -72,10 +71,7 @@ fun ReviewItem(
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .size(36.dp)
-                        .clip(RoundedCornerShape(100))
-                        .clickable {
-                            onClick(review.userId)
-                        },
+                        .clip(RoundedCornerShape(100)),
                     error = painterResource(id = R.drawable.tmp_jeju)
                 )
 
@@ -87,10 +83,6 @@ fun ReviewItem(
                     Text(
                         text = review.username,
                         style = Body1Bold,
-                        modifier = Modifier
-                            .clickable {
-                                onClick(review.userId)
-                            }
                     )
 
                     ReviewStar(

--- a/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewList.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewList.kt
@@ -10,8 +10,7 @@ import com.tlog.data.model.travel.Review
 @Composable
 fun ReviewList(
     reviewList: List<Review>,
-    maxCnt: Int = Int.MAX_VALUE,
-    onClick: (String) -> Unit
+    maxCnt: Int = Int.MAX_VALUE
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(29.dp)
@@ -23,8 +22,7 @@ fun ReviewList(
             val review = reviewList[i]
 
             ReviewItem(
-                review = review,
-                onClick = onClick
+                review = review
             )
         }
     }

--- a/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewSection.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewSection.kt
@@ -30,8 +30,7 @@ fun ReviewSection(
     reviewList: List<Review>,
     reviewCnt: Int = Int.MAX_VALUE,
     moreReview: () -> Unit,
-    reviewWrite: () -> Unit,
-    onClick: (String) -> Unit
+    reviewWrite: () -> Unit
 ) {
     Column {
         Column(

--- a/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewSection.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/component/travel/review/ReviewSection.kt
@@ -96,8 +96,7 @@ fun ReviewSection(
         ) {
             ReviewList(
                 reviewList = reviewList,
-                maxCnt = reviewCnt,
-                onClick = onClick
+                maxCnt = reviewCnt
             )
         }
     }

--- a/Tlog/app/src/main/java/com/tlog/ui/screen/review/ReviewListScreen.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/screen/review/ReviewListScreen.kt
@@ -150,10 +150,7 @@ fun ReviewListScreen(
                     Spacer(modifier = Modifier.height(29.dp))
 
                     ReviewList(
-                        reviewList = viewModel.reviewList.value,
-                        onClick = { userId ->
-                            viewModel.navToSnsMyPage(userId)
-                        }
+                        reviewList = viewModel.reviewList.value
                     )
                 }
             }

--- a/Tlog/app/src/main/java/com/tlog/ui/screen/travel/TravelDetailScreen.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/screen/travel/TravelDetailScreen.kt
@@ -108,9 +108,6 @@ fun TravelDetailScreen(
                             },
                             reviewWrite = {
                                 viewModel.navToReviewWrite(travelId, destination.name)
-                            },
-                            onClick = { userId ->
-                                viewModel.navToSnsMyPage(userId)
                             }
                         )
 


### PR DESCRIPTION
## 작업 동기 및 이슈
- #244 

## 추가 및 변경사항
- 여행지 정보 스크린 / 리뷰 리스트 스크린에서 리뷰 유저 프로필을 눌렀을 때 SNS로 이동하지 않도록 관련 코드 삭제
 
## 기타

## 실행 화면
