### PR TITLE
feat: 팀장 여부에 따른 팀 떠나기 / 삭제 로직 수정, OTP 버그 수정

### DIFF
--- a/Tlog/app/src/main/java/com/tlog/api/TeamApi.kt
+++ b/Tlog/app/src/main/java/com/tlog/api/TeamApi.kt
@@ -16,26 +16,32 @@ import retrofit2.http.Query
 interface TeamApi {
     @GET("/api/team")
     suspend fun getTeamList(
-        @Query("userId") userId: String
+        @Query("userId") userId: String,
     ): BaseResponse<List<Team>>
 
     @POST("/api/team")
     suspend fun createTeam(
-        @Body request: CreateTeamRequest
+        @Body request: CreateTeamRequest,
     ): BaseResponse<TeamCreateResponse>
 
     @DELETE("/api/team/{teamId}")
     suspend fun deleteTeam(
-        @Path("teamId") teamId: String
+        @Path("teamId") teamId: String,
     ): BaseResponse<String>
 
     @GET("/api/team/{teamId}/details")
     suspend fun getTeamDetails(
-        @Path("teamId") teamId: String
+        @Path("teamId") teamId: String,
     ): BaseResponse<DetailTeam>
 
     @POST("/api/team/join")
     suspend fun joinTeam(
-        @Body request: JoinTeamRequest
+        @Body request: JoinTeamRequest,
     ): BaseResponse<Unit>
+
+    @DELETE("/api/team/member/{teamId}/{userId}")
+    suspend fun leaveTeam(
+        @Path("teamId") teamId: String,
+        @Path("userId") userId: String,
+    ): BaseResponse<String>
 }

--- a/Tlog/app/src/main/java/com/tlog/data/model/team/Team.kt
+++ b/Tlog/app/src/main/java/com/tlog/data/model/team/Team.kt
@@ -3,6 +3,7 @@ package com.tlog.data.model.team
 data class Team(
     val teamId: String,
     val teamName: String,
+    val teamLeaderId: String,
     val teamLeaderName: String,
     val memberIdList: List<String>
 )

--- a/Tlog/app/src/main/java/com/tlog/data/repository/TeamRepository.kt
+++ b/Tlog/app/src/main/java/com/tlog/data/repository/TeamRepository.kt
@@ -29,13 +29,16 @@ class TeamRepository @Inject constructor(
 
     suspend fun createTeam(request: CreateTeamRequest): BaseResponse<TeamCreateResponse>{
         val result = retrofitInstance.createTeam(request)
-        Log.d("ReviewRepository", "addReview: $result")
         return result
     }
 
     suspend fun deleteTeam(teamId: String): BaseResponse<String> {
         val result = retrofitInstance.deleteTeam(teamId)
-        Log.d("TeamDeleteRepository", "deleteTeam: $result")
+        return result
+    }
+
+    suspend fun leaveTeam(teamId: String, userId: String): BaseResponse<String> {
+        val result = retrofitInstance.leaveTeam(teamId, userId)
         return result
     }
 }

--- a/Tlog/app/src/main/java/com/tlog/ui/component/share/OtpCodeInput.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/component/share/OtpCodeInput.kt
@@ -111,6 +111,181 @@ fun OtpCodeInput(
                                         currentFocusIndex.value = nextIndex
                                     }
                                 }
+
+                            }
+                        },
+                        isNumber = isNumber,
+                        focusRequester = requester,
+                        index = i,
+                        currentFocusIndex = currentFocusIndex
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun InputFeild(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    isNumber: Boolean = true,
+    focusRequester: FocusRequester,
+    index: Int,
+    currentFocusIndex: MutableState<Int>
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier
+            .padding(horizontal = 5.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color(0xFFF3F3F3))
+            .wrapContentSize()
+            .focusRequester(focusRequester),
+        maxLines = 1,
+        cursorBrush = SolidColor(Color.White),
+        textStyle = TextStyle(
+            color = Color.Black,
+            fontSize = 26.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        ),
+        keyboardOptions = KeyboardOptions(
+            keyboardType = if(isNumber) KeyboardType.Number else KeyboardType.Text,
+//            imeAction = ImeAction.Done
+        ),
+//        keyboardActions = KeyboardActions(
+//            onDone = null
+//        ),
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .width(35.dp)
+                    .height(50.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                innerTextField()
+            }
+        }
+    )
+}
+
+
+/*
+package com.tlog.ui.component.share
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.input.key.*
+
+@Composable
+fun OtpCodeInput(
+    textList: List<MutableState<TextFieldValue>>,
+    requesterList: List<FocusRequester>,
+    isNumber: Boolean = true,
+    onComplete: (String) -> Unit
+) {
+    val currentFocusIndex = remember { mutableStateOf(0) } // 포커스 1개로만 관리하기 위해서 만든 변수
+
+    Surface(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
+            Row(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 50.dp)
+                    .align(Alignment.TopCenter)
+            ) {
+                for (i in textList.indices) {
+                    val requester = requesterList[i]
+
+                    // 현재 포커스 인덱스에 해당하는 필드에만 포커스 요청하도록
+                    LaunchedEffect(currentFocusIndex.value) {
+                        if (currentFocusIndex.value == i)
+                            requester.requestFocus()
+                    }
+
+
+                    InputFeild(
+                        value = textList[i].value,
+                        onValueChange = { newValue ->
+                            val input = if (isNumber) newValue.text.filter { it.isDigit() } else newValue.text
+                            val oldText = textList[i].value.text
+
+                            when {
+                                // 백스페이스
+                                oldText.isNotEmpty() && input.isEmpty() -> {
+                                    textList[i].value = TextFieldValue("", TextRange(0))
+                                    if (i > 0) {
+                                        currentFocusIndex.value = i - 1
+                                    }
+                                }
+
+                                // 문자 1개 입력
+                                input.length == 1 && oldText.isEmpty() -> {
+                                    textList[i].value = TextFieldValue(input, TextRange(1))
+                                    // 포커스 이동
+                                    if (i < textList.size - 1) {
+                                        currentFocusIndex.value = i + 1
+                                    } else {
+                                        val code = textList.joinToString("") { it.value.text }
+                                        if (code.length == textList.size) {
+                                            onComplete(code)
+                                        }
+                                    }
+                                }
+
+                                // 붙여넣기
+                                input.length > 1 -> {
+                                    val maxLength = textList.size - i
+                                    val subInput = input.take(maxLength)
+
+                                    for ((offset, char) in subInput.withIndex()) {
+                                        val targetIndex = i + offset
+                                        if (targetIndex < textList.size) {
+                                            textList[targetIndex].value = TextFieldValue(
+                                                char.toString(),
+                                                TextRange(1)
+                                            )
+                                        }
+                                    }
+
+                                    val code = textList.joinToString("") { it.value.text }
+                                    if (code.length == textList.size) {
+                                        onComplete(code)
+                                    } else {
+                                        val nextIndex = (i + subInput.length).coerceAtMost(textList.size - 1)
+                                        currentFocusIndex.value = nextIndex
+                                    }
+                                }
                             }
                         },
                         isNumber = isNumber,
@@ -181,3 +356,4 @@ fun InputFeild(
         }
     )
 }
+ */

--- a/Tlog/app/src/main/java/com/tlog/ui/screen/team/MyTeamListScreen.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/screen/team/MyTeamListScreen.kt
@@ -23,7 +23,7 @@ import com.tlog.viewmodel.team.MyTeamListViewModel
 @Composable
 fun MyTeamListScreen(
     viewModel: MyTeamListViewModel = hiltViewModel(),
-    navController: NavHostController
+    navController: NavHostController,
 ) {
     val context = LocalContext.current
 
@@ -34,12 +34,17 @@ fun MyTeamListScreen(
             when (event) {
                 is UiEvent.Navigate -> {
                     navController.navigate(event.target) {
-                        if (event.clearBackStack) popUpTo(navController.graph.id) { inclusive = true }
+                        if (event.clearBackStack) popUpTo(navController.graph.id) {
+                            inclusive = true
+                        }
                         launchSingleTop = true
                         restoreState = false
                     }
                 }
-                is UiEvent.ShowToast -> Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+
+                is UiEvent.ShowToast -> Toast.makeText(context, event.message, Toast.LENGTH_SHORT)
+                    .show()
+
                 is UiEvent.PopBackStack -> Unit
             }
         }
@@ -71,7 +76,7 @@ fun MyTeamListScreen(
             ) { team ->
                 TeamCard(
                     team = team,
-                    onDeleteClick = { viewModel.deleteTeam(it) },
+                    onDeleteClick = { viewModel.deleteTeam(it, team.teamLeaderId) },
                     onClick = { teamId ->
                         viewModel.navToTeamDetail(teamId)
                     }

--- a/Tlog/app/src/main/java/com/tlog/ui/screen/team/TeamJoinScreen.kt
+++ b/Tlog/app/src/main/java/com/tlog/ui/screen/team/TeamJoinScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -42,7 +41,6 @@ fun TeamJoinScreen(
     navController: NavController
 ) {
     val context = LocalContext.current
-    val focusManager = LocalFocusManager.current
     val codeError = viewModel.codeError
     val isCodeValid = viewModel.isCodeValid
     val textList = viewModel.textList
@@ -110,9 +108,6 @@ fun TeamJoinScreen(
                 isNumber = false,
                 onComplete = { code ->
                     viewModel.onCodeEntered(code)
-                    if (viewModel.isCodeValid.value) {
-                        focusManager.clearFocus()
-                    }
                 }
             )
 

--- a/Tlog/app/src/main/java/com/tlog/viewmodel/team/MyTeamListViewModel.kt
+++ b/Tlog/app/src/main/java/com/tlog/viewmodel/team/MyTeamListViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyTeamListViewModel @Inject constructor(
     private val teamRepository: TeamRepository,
-    tokenProvider: TokenProvider
+    tokenProvider: TokenProvider,
 ) : BaseViewModel() {
 
 
@@ -22,7 +22,6 @@ class MyTeamListViewModel @Inject constructor(
     init {
         userId = tokenProvider.getUserId()
     }
-
 
 
     private val _teamList = mutableStateOf<List<Team>>(emptyList())
@@ -40,15 +39,24 @@ class MyTeamListViewModel @Inject constructor(
         )
     }
 
-    fun deleteTeam(teamId: String) {
+    fun deleteTeam(teamId: String, teamLeaderId: String) {
         launchSafeCall(
             action = {
-                teamRepository.deleteTeam(teamId)
+                if (teamLeaderId == userId) {
+                    teamRepository.deleteTeam(teamId)
 
-                _teamList.value = _teamList.value.filterNot { it.teamId == teamId }
+                    _teamList.value = _teamList.value.filterNot { it.teamId == teamId }
+                    showToast("팀 삭제 성공")
+                } else {
+                    teamRepository.leaveTeam(teamId, userId!!)
+
+                    _teamList.value = _teamList.value.filterNot { it.teamId == teamId }
+                    showToast("팀 떠나기 성공")
+                }
             }
         )
     }
+
 
     fun navToCreateTeam() {
         navigate(Screen.CreateTeam)


### PR DESCRIPTION
## 작업 동기 및 이슈
- #246 

## 추가 및 변경사항
- 코드로 팀 참가 시 사용하는 OTP 코드 수정
- api 변경으로 Team 클래스에 teamLeaderId 추가
- 팀 리더일 시 팀 삭제 / 팀 멤버일 시 팀 나가기로 로직 수정

## 기타

## 실행 화면
<img width="1052" height="495" alt="스크린샷 2025-10-28 오전 12 08 13" src="https://github.com/user-attachments/assets/fde4fd6d-d107-4e1f-86dd-dd0684584e32" />
[팀 삭제, 나가기 api 결과]
